### PR TITLE
Register template paths in themes and modules through their info.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha2] - 2022-06-28
+### Changed
+- Register template paths in themes and modules through their info.yml files.
+
 ## [1.0.0-alpha1] - 2022-06-28
 First tagged version.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,40 @@ installed using Composer:
  composer require wieni/wmtwig
 ```
 
+## How does it work?
+### Registering Twig templates as theme implementations
+This module automatically registers your Twig templates as theme implementations. Modules and themes can indicate in 
+their info.yml file which paths should be included:
+
+```yaml
+name: Some theme
+type: theme
+
+wmtwig:
+    templates: pages
+```
+
+If the module or theme has multiple paths, an array can be passed:
+
+```yaml
+name: Some theme
+type: theme
+
+wmtwig:
+    templates:
+        - components
+        - pages
+```
+
+The advantage against the default way of rendering Twig templates
+([see documentation](https://www.drupal.org/docs/theming-drupal/twig-in-drupal/create-custom-twig-templates-for-custom-module))
+is that you don't have to manually define every template in a theme hook. Also, the folder structure of your templates is respected. This makes it possible to refer to templates in the same
+way as in Laravel projects, eg. `node.product` for the `node/product.html.twig` template.
+
+It is recommended to not use the default `templates` folder for these templates, because they might clash with other 
+Drupal theme implementations. Eg. when creating a template at path `templates/node/page.html.twig`, it will override 
+the core page template.
+
 ## Changelog
 All notable changes to this project will be documented in the
 [CHANGELOG](CHANGELOG.md) file.

--- a/wmtwig.info.yml
+++ b/wmtwig.info.yml
@@ -1,6 +1,5 @@
 name: Wieni Twig
 type: module
 description: Improves the integration of Twig with component and entity-oriented projects
-core: 8.x
 core_version_requirement: ^8 || ^9
 package: Wieni

--- a/wmtwig.services.yml
+++ b/wmtwig.services.yml
@@ -1,19 +1,9 @@
-parameters:
-    wmtwig.settings:
-        # The module where your templates can be found (optional)
-        module: ''
-        # The theme where your templates can be found (optional)
-        theme: ''
-        # The relative path your templates reside in.
-        # (relative to your module / theme dir)
-        path: 'templates'
-
 services:
     wmtwig.template_locator:
         class: Drupal\wmtwig\TemplateLocator
         arguments:
+            - '@module_handler'
             - '@theme_handler'
-            - '%wmtwig.settings%'
 
     wmtwig.subscriber.template_parameter_cacheable_dependency:
         class: Drupal\wmtwig\EventSubscriber\TemplateParameterCacheableDependencySubscriber

--- a/wmtwig.services.yml
+++ b/wmtwig.services.yml
@@ -2,8 +2,8 @@ services:
     wmtwig.template_locator:
         class: Drupal\wmtwig\TemplateLocator
         arguments:
-            - '@module_handler'
-            - '@theme_handler'
+            - '@extension.list.module'
+            - '@extension.list.theme'
 
     wmtwig.subscriber.template_parameter_cacheable_dependency:
         class: Drupal\wmtwig\EventSubscriber\TemplateParameterCacheableDependencySubscriber


### PR DESCRIPTION
## Description

This module automatically registers your Twig templates as theme implementations. Modules and themes can indicate in 
their info.yml file which paths should be included:

```yaml
name: Some theme
type: theme

wmtwig:
    templates: pages
```

If the module or theme has multiple paths, an array can be passed:

```yaml
name: Some theme
type: theme

wmtwig:
    templates:
        - components
        - pages
```